### PR TITLE
Updated indent rule configuration

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -10,7 +10,7 @@
     "comma-dangle": [2, "never"],
     "comma-style": 2,
     "default-case": 2,
-    "indent": [2, 2],
+    "indent": [2, 2, {"VariableDeclarator": 2, "SwitchCase": 1}],
     "no-cond-assign": 2,
     "no-console": 2,
     "no-constant-condition": 2,

--- a/config/base.json
+++ b/config/base.json
@@ -42,6 +42,7 @@
     "no-sparse-arrays": 2,
     "no-undef": 2,
     "no-underscore-dangle": 0,
+    "no-unexpected-multiline": 2,
     "no-unreachable": 2,
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
     "no-use-before-define": [2, "nofunc"],

--- a/config/base.json
+++ b/config/base.json
@@ -36,12 +36,10 @@
     "no-negated-in-lhs": 2,
     "no-obj-calls": 2,
     "no-octal": 2,
-    "no-process-exit": 0,
     "no-redeclare": 2,
     "no-regex-spaces": 2,
     "no-sparse-arrays": 2,
     "no-undef": 2,
-    "no-underscore-dangle": 0,
     "no-unexpected-multiline": 2,
     "no-unreachable": 2,
     "no-unused-vars": [2, {"vars": "all", "args": "none"}],
@@ -55,7 +53,6 @@
     "space-infix-ops": 2,
     "space-return-throw-case": 2,
     "space-unary-ops": 2,
-    "strict": 0,
     "use-isnan": 2,
     "valid-jsdoc": [2, {
       "requireReturn": false


### PR DESCRIPTION
This updates the `indent` rule configuration to enforce two indents in multi-line variable declarators and one in switch-case statements.

So for multi-line variable declarators:
```js
var foo,
    bar; // four spaces (two indents)
```

And for switch-case:
```js
switch (foo) {
  case 'bar':
    alert('bam');
    break;
  default:
    alert('baz');
}
```

In addition, this adds the `no-unexpected-multiline` rule (to avoid unexpected semicolon insertion).  And two disabled rules are removed (this has no effect).