### PR TITLE
Add eol-last and no-trailing-spaces rules

### DIFF
--- a/config/base.json
+++ b/config/base.json
@@ -10,6 +10,7 @@
     "comma-dangle": [2, "never"],
     "comma-style": 2,
     "default-case": 2,
+    "eol-last": 2,
     "indent": [2, 2, {"VariableDeclarator": 2, "SwitchCase": 1}],
     "no-cond-assign": 2,
     "no-console": 2,

--- a/config/base.json
+++ b/config/base.json
@@ -40,6 +40,7 @@
     "no-redeclare": 2,
     "no-regex-spaces": 2,
     "no-sparse-arrays": 2,
+    "no-trailing-spaces": 2,
     "no-undef": 2,
     "no-unexpected-multiline": 2,
     "no-unreachable": 2,


### PR DESCRIPTION
With these two rules, we can get rid of https://github.com/openlayers/ol3/blob/master/bin/check-whitespace.py