### PR TITLE
Add peerDependencies on eslint ^1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
     "code": "^1.5.0",
     "eslint": "^1.3.1",
     "lab": "^5.15.2"
+  },
+  "peerDependencies": {
+    "eslint": "^1.0.0"
   }
 }


### PR DESCRIPTION
Because eslint-config-openlayers is not compatible with ESLint v2