### PR TITLE
Enable the curly rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'brace-style': 2,
     'comma-dangle': [2, 'never'],
     'comma-style': 2,
+    'curly': 2,
     'default-case': 2,
     'eol-last': 2,
     'indent': [2, 2, {VariableDeclarator: 2, SwitchCase: 1}],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
     "extends": "./index.js"
   },
   "devDependencies": {
-    "eslint": "^2.3.0"
+    "eslint": "^3.10.0"
   }
 }


### PR DESCRIPTION
This was an oversight.  Our style convention has always called for braces around conditional blocks.
