### PR TITLE
use eslint-plugin-jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = {
     'jsdoc/require-param-name': 'error',
     'jsdoc/require-param-type': 'error',
     'jsdoc/require-property': 'error',
-    'jsdoc/require-property-description': 'error',
+    // 'jsdoc/require-property-description': 'error',
     'jsdoc/require-property-name': 'error',
     'jsdoc/require-property-type': 'error',
     'jsdoc/require-returns': 'error',
@@ -130,6 +130,7 @@ module.exports = {
       mode: 'typescript',
       tagNamePreference: {
         'returns': 'return',
+        'file': 'fileoverview',
         'constant': 'const',
         'augments': 'extends',
       },

--- a/index.js
+++ b/index.js
@@ -17,49 +17,58 @@ module.exports = {
     'import/named': 'error',
     'import/default': 'error',
     'import/extensions': ['error', 'always', {ignorePackages: true}],
+
+    // validity
     "jsdoc/check-access": 'error',
-    "jsdoc/check-alignment": 'error',
-    "jsdoc/check-examples": 'error',
-    "jsdoc/check-indentation": 'off',
-    "jsdoc/check-line-alignment": 'error',
     "jsdoc/check-param-names": 'error',
     "jsdoc/check-property-names": 'error',
-    "jsdoc/check-syntax": 'error',
+    // "jsdoc/check-syntax": 'error', // the mode is 'typescript' and it errors for closure syntax
     "jsdoc/check-tag-names": ['error', {
       "definedTags": ["api"]
     }],
-    "jsdoc/check-types": 'error',
-    "jsdoc/check-values": 'error',
     "jsdoc/empty-tags": 'error',
     "jsdoc/implements-on-classes": 'error',
-    "jsdoc/match-description": 'off',
-    "jsdoc/newline-after-description": 'off',
     "jsdoc/no-bad-blocks": 'error',
-    "jsdoc/no-defaults": 'error',
-    "jsdoc/no-types": 'off',
-    "jsdoc/no-undefined-types": ['error', {
-      'definedTypes': ['ol'] // should this be allowed?
-    }],
-    "jsdoc/require-description": 'off',
-    "jsdoc/require-description-complete-sentence": 'off', // some issues with description starting with line break
-    "jsdoc/require-example": 'off',
-    "jsdoc/require-file-overview": 'off',
-    "jsdoc/require-hyphen-before-param-description": ['error', 'never'],
-    "jsdoc/require-jsdoc": 'off',
+    // "jsdoc/no-undefined-types": ['error', { 'definedTypes': ['ol'] }],
+      // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/559
+      // for main source this should not be needed because tsc already checks it
     "jsdoc/require-param": 'error',
-    "jsdoc/require-param-description": 'error',
+    "jsdoc/require-param-description": 'error', // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/686
     "jsdoc/require-param-name": 'error',
     "jsdoc/require-param-type": 'error',
     "jsdoc/require-property": 'error',
     "jsdoc/require-property-description": 'error',
     "jsdoc/require-property-name": 'error',
     "jsdoc/require-property-type": 'error',
-    "jsdoc/require-returns": 'off',
+    "jsdoc/require-returns": 'error',
     "jsdoc/require-returns-check": 'error',
     "jsdoc/require-returns-description": 'error',
     "jsdoc/require-returns-type": 'error',
-    "jsdoc/require-yields": 'error',
-    "jsdoc/valid-types": 'error',
+    // "jsdoc/valid-types": 'error', // this fails because of https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
+      // for main source this should not be needed because tsc already checks it
+    // "jsdoc/check-types": 'error', // for primitives. is aligned with mode 'typescript'. Needed because of tsc?
+
+    // stylistic
+    "jsdoc/check-alignment": 'error',
+    "jsdoc/check-examples": 'error',
+    "jsdoc/require-hyphen-before-param-description": ['error', 'never'],
+
+    // turned off
+    // "jsdoc/check-indentation": 'error', // we want indentation in certain cases
+    // "jsdoc/check-line-alignment": 'error',
+    // "jsdoc/check-values": 'error', // not needed
+    // "jsdoc/match-description": 'error', // regex could get adjusted ...
+    // "jsdoc/newline-after-description": 'error',
+    // "jsdoc/no-defaults": 'error',
+    // "jsdoc/no-types": 'error',
+    // "jsdoc/require-description": 'error',
+    // "jsdoc/require-description-complete-sentence": 'error', // some issues with description starting with line break
+    // "jsdoc/require-example": 'error',
+    // "jsdoc/require-file-overview": 'error',
+    // "jsdoc/require-jsdoc": 'error',
+    // "jsdoc/require-throws": 'error',
+    // "jsdoc/require-yields": 'error',
+
     'no-cond-assign': 'error',
     'no-console': 'error',
     'no-const-assign': 'error',

--- a/index.js
+++ b/index.js
@@ -17,8 +17,6 @@ module.exports = {
     'import/named': 'error',
     'import/default': 'error',
     'import/extensions': ['error', 'always', {ignorePackages: true}],
-
-    // validity
     'jsdoc/check-access': 'error',
     'jsdoc/check-param-names': 'error',
     'jsdoc/check-property-names': 'error',
@@ -32,11 +30,9 @@ module.exports = {
     'jsdoc/empty-tags': 'error',
     'jsdoc/implements-on-classes': 'error',
     'jsdoc/no-bad-blocks': 'error',
-    // "jsdoc/no-undefined-types": ['error', { 'definedTypes': ['ol'] }],
-    // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/559
-    // for main source this should not be needed because tsc already checks it
+    // "jsdoc/no-undefined-types": ['error', { 'definedTypes': ['ol'] }], // blocked by https://github.com/gajus/eslint-plugin-jsdoc/issues/559
     'jsdoc/require-param': 'error',
-    'jsdoc/require-param-description': 'error', // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/686
+    'jsdoc/require-param-description': 'error',
     'jsdoc/require-param-name': 'error',
     'jsdoc/require-param-type': 'error',
     'jsdoc/require-property': 'error',
@@ -47,31 +43,11 @@ module.exports = {
     'jsdoc/require-returns-check': 'error',
     'jsdoc/require-returns-description': 'error',
     'jsdoc/require-returns-type': 'error',
-    // "jsdoc/valid-types": 'error', // this fails because of https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
-    // for main source this should not be needed because tsc already checks it
-    // "jsdoc/check-types": 'error', // for primitives. is aligned with mode 'typescript'. Not needed because of tsc?
-
-    // stylistic
+    // "jsdoc/valid-types": 'error', // blocked by https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
+    'jsdoc/check-types': 'error',
     'jsdoc/check-alignment': 'error',
     'jsdoc/check-examples': 'error',
     'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
-
-    // turned off
-    // "jsdoc/check-indentation": 'error', // we want indentation in certain cases
-    // "jsdoc/check-line-alignment": 'error',
-    // "jsdoc/check-values": 'error', // not needed
-    // "jsdoc/match-description": 'error', // regex could get adjusted ...
-    // "jsdoc/newline-after-description": 'error',
-    // "jsdoc/no-defaults": 'error',
-    // "jsdoc/no-types": 'error',
-    // "jsdoc/require-description": 'error',
-    // "jsdoc/require-description-complete-sentence": 'error', // some issues with description starting with line break
-    // "jsdoc/require-example": 'error',
-    // "jsdoc/require-file-overview": 'error',
-    // "jsdoc/require-jsdoc": 'error',
-    // "jsdoc/require-throws": 'error',
-    // "jsdoc/require-yields": 'error',
-
     'no-cond-assign': 'error',
     'no-console': 'error',
     'no-const-assign': 'error',
@@ -128,6 +104,10 @@ module.exports = {
   settings: {
     jsdoc: {
       mode: 'typescript',
+      preferredTypes: {
+        '[]': 'Array<>',
+        '.<>': '<>',
+      },
       tagNamePreference: {
         'returns': 'return',
         'file': 'fileoverview',

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
-  plugins: ['import', 'sort-imports-es6-autofix', 'prettier'],
+  plugins: ['import', 'sort-imports-es6-autofix', 'prettier', 'jsdoc'],
   extends: ['prettier'],
   rules: {
     'block-scoped-var': 'error',
@@ -17,6 +17,49 @@ module.exports = {
     'import/named': 'error',
     'import/default': 'error',
     'import/extensions': ['error', 'always', {ignorePackages: true}],
+    "jsdoc/check-access": 'error',
+    "jsdoc/check-alignment": 'error',
+    "jsdoc/check-examples": 'error',
+    "jsdoc/check-indentation": 'off',
+    "jsdoc/check-line-alignment": 'error',
+    "jsdoc/check-param-names": 'error',
+    "jsdoc/check-property-names": 'error',
+    "jsdoc/check-syntax": 'error',
+    "jsdoc/check-tag-names": ['error', {
+      "definedTags": ["api"]
+    }],
+    "jsdoc/check-types": 'error',
+    "jsdoc/check-values": 'error',
+    "jsdoc/empty-tags": 'error',
+    "jsdoc/implements-on-classes": 'error',
+    "jsdoc/match-description": 'off',
+    "jsdoc/newline-after-description": 'off',
+    "jsdoc/no-bad-blocks": 'error',
+    "jsdoc/no-defaults": 'error',
+    "jsdoc/no-types": 'off',
+    "jsdoc/no-undefined-types": ['error', {
+      'definedTypes': ['ol'] // should this be allowed?
+    }],
+    "jsdoc/require-description": 'off',
+    "jsdoc/require-description-complete-sentence": 'off', // some issues with description starting with line break
+    "jsdoc/require-example": 'off',
+    "jsdoc/require-file-overview": 'off',
+    "jsdoc/require-hyphen-before-param-description": ['error', 'never'],
+    "jsdoc/require-jsdoc": 'off',
+    "jsdoc/require-param": 'error',
+    "jsdoc/require-param-description": 'error',
+    "jsdoc/require-param-name": 'error',
+    "jsdoc/require-param-type": 'error',
+    "jsdoc/require-property": 'error',
+    "jsdoc/require-property-description": 'error',
+    "jsdoc/require-property-name": 'error',
+    "jsdoc/require-property-type": 'error',
+    "jsdoc/require-returns": 'off',
+    "jsdoc/require-returns-check": 'error',
+    "jsdoc/require-returns-description": 'error',
+    "jsdoc/require-returns-type": 'error',
+    "jsdoc/require-yields": 'error',
+    "jsdoc/valid-types": 'error',
     'no-cond-assign': 'error',
     'no-console': 'error',
     'no-const-assign': 'error',
@@ -68,12 +111,14 @@ module.exports = {
       },
     ],
     'use-isnan': 'error',
-    'valid-jsdoc': [
-      'error',
-      {
-        requireReturn: false,
-      },
-    ],
-    'valid-typeof': 'error',
+    'valid-typeof': 'error'
   },
+  'settings': {
+    'jsdoc': {
+      'mode': 'typescript',
+      "tagNamePreference": {
+        "returns": "return"
+      }
+    }
+  }
 };

--- a/index.js
+++ b/index.js
@@ -18,19 +18,23 @@ module.exports = {
     'import/default': 'error',
     'import/extensions': ['error', 'always', {ignorePackages: true}],
     'jsdoc/check-access': 'error',
+    'jsdoc/check-alignment': 'error',
+    'jsdoc/check-examples': 'error',
     'jsdoc/check-param-names': 'error',
     'jsdoc/check-property-names': 'error',
-    // "jsdoc/check-syntax": 'error', // the mode is 'typescript' and it errors for closure syntax
+    'jsdoc/check-syntax': 'error',
     'jsdoc/check-tag-names': [
       'error',
       {
         definedTags: ['api', 'observable'],
       },
     ],
+    'jsdoc/check-types': 'error',
     'jsdoc/empty-tags': 'error',
     'jsdoc/implements-on-classes': 'error',
     'jsdoc/no-bad-blocks': 'error',
     // "jsdoc/no-undefined-types": ['error', { 'definedTypes': ['ol'] }], // blocked by https://github.com/gajus/eslint-plugin-jsdoc/issues/559
+    'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
     'jsdoc/require-param': 'error',
     'jsdoc/require-param-description': 'error',
     'jsdoc/require-param-name': 'error',
@@ -44,10 +48,6 @@ module.exports = {
     'jsdoc/require-returns-description': 'error',
     'jsdoc/require-returns-type': 'error',
     // "jsdoc/valid-types": 'error', // blocked by https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
-    'jsdoc/check-types': 'error',
-    'jsdoc/check-alignment': 'error',
-    'jsdoc/check-examples': 'error',
-    'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
     'no-cond-assign': 'error',
     'no-console': 'error',
     'no-const-assign': 'error',

--- a/index.js
+++ b/index.js
@@ -19,39 +19,42 @@ module.exports = {
     'import/extensions': ['error', 'always', {ignorePackages: true}],
 
     // validity
-    "jsdoc/check-access": 'error',
-    "jsdoc/check-param-names": 'error',
-    "jsdoc/check-property-names": 'error',
+    'jsdoc/check-access': 'error',
+    'jsdoc/check-param-names': 'error',
+    'jsdoc/check-property-names': 'error',
     // "jsdoc/check-syntax": 'error', // the mode is 'typescript' and it errors for closure syntax
-    "jsdoc/check-tag-names": ['error', {
-      "definedTags": ["api"]
-    }],
-    "jsdoc/empty-tags": 'error',
-    "jsdoc/implements-on-classes": 'error',
-    "jsdoc/no-bad-blocks": 'error',
+    'jsdoc/check-tag-names': [
+      'error',
+      {
+        definedTags: ['api', 'observable'],
+      },
+    ],
+    'jsdoc/empty-tags': 'error',
+    'jsdoc/implements-on-classes': 'error',
+    'jsdoc/no-bad-blocks': 'error',
     // "jsdoc/no-undefined-types": ['error', { 'definedTypes': ['ol'] }],
-      // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/559
-      // for main source this should not be needed because tsc already checks it
-    "jsdoc/require-param": 'error',
-    "jsdoc/require-param-description": 'error', // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/686
-    "jsdoc/require-param-name": 'error',
-    "jsdoc/require-param-type": 'error',
-    "jsdoc/require-property": 'error',
-    "jsdoc/require-property-description": 'error',
-    "jsdoc/require-property-name": 'error',
-    "jsdoc/require-property-type": 'error',
-    "jsdoc/require-returns": 'error',
-    "jsdoc/require-returns-check": 'error',
-    "jsdoc/require-returns-description": 'error',
-    "jsdoc/require-returns-type": 'error',
+    // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/559
+    // for main source this should not be needed because tsc already checks it
+    'jsdoc/require-param': 'error',
+    'jsdoc/require-param-description': 'error', // this fails because of https://github.com/gajus/eslint-plugin-jsdoc/issues/686
+    'jsdoc/require-param-name': 'error',
+    'jsdoc/require-param-type': 'error',
+    'jsdoc/require-property': 'error',
+    'jsdoc/require-property-description': 'error',
+    'jsdoc/require-property-name': 'error',
+    'jsdoc/require-property-type': 'error',
+    'jsdoc/require-returns': 'error',
+    'jsdoc/require-returns-check': 'error',
+    'jsdoc/require-returns-description': 'error',
+    'jsdoc/require-returns-type': 'error',
     // "jsdoc/valid-types": 'error', // this fails because of https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
-      // for main source this should not be needed because tsc already checks it
-    // "jsdoc/check-types": 'error', // for primitives. is aligned with mode 'typescript'. Needed because of tsc?
+    // for main source this should not be needed because tsc already checks it
+    // "jsdoc/check-types": 'error', // for primitives. is aligned with mode 'typescript'. Not needed because of tsc?
 
     // stylistic
-    "jsdoc/check-alignment": 'error',
-    "jsdoc/check-examples": 'error',
-    "jsdoc/require-hyphen-before-param-description": ['error', 'never'],
+    'jsdoc/check-alignment': 'error',
+    'jsdoc/check-examples': 'error',
+    'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
 
     // turned off
     // "jsdoc/check-indentation": 'error', // we want indentation in certain cases
@@ -120,14 +123,16 @@ module.exports = {
       },
     ],
     'use-isnan': 'error',
-    'valid-typeof': 'error'
+    'valid-typeof': 'error',
   },
-  'settings': {
-    'jsdoc': {
-      'mode': 'typescript',
-      "tagNamePreference": {
-        "returns": "return"
-      }
-    }
-  }
+  settings: {
+    jsdoc: {
+      mode: 'typescript',
+      tagNamePreference: {
+        'returns': 'return',
+        'constant': 'const',
+        'augments': 'extends',
+      },
+    },
+  },
 };

--- a/index.js
+++ b/index.js
@@ -33,21 +33,21 @@ module.exports = {
     'jsdoc/empty-tags': 'error',
     'jsdoc/implements-on-classes': 'error',
     'jsdoc/no-bad-blocks': 'error',
-    // "jsdoc/no-undefined-types": ['error', { 'definedTypes': ['ol'] }], // blocked by https://github.com/gajus/eslint-plugin-jsdoc/issues/559
+    // 'jsdoc/no-undefined-types': ['error', { 'definedTypes': ['ol'] }], // blocked by https://github.com/gajus/eslint-plugin-jsdoc/issues/559
     'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
     'jsdoc/require-param': 'error',
     'jsdoc/require-param-description': 'error',
     'jsdoc/require-param-name': 'error',
     'jsdoc/require-param-type': 'error',
     'jsdoc/require-property': 'error',
-    // 'jsdoc/require-property-description': 'error',
+    'jsdoc/require-property-description': 'error',
     'jsdoc/require-property-name': 'error',
     'jsdoc/require-property-type': 'error',
     'jsdoc/require-returns': 'error',
     'jsdoc/require-returns-check': 'error',
     'jsdoc/require-returns-description': 'error',
     'jsdoc/require-returns-type': 'error',
-    // "jsdoc/valid-types": 'error', // blocked by https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
+    // 'jsdoc/valid-types': 'error', // blocked by https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133
     'no-cond-assign': 'error',
     'no-console': 'error',
     'no-const-assign': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,6 +244,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "comment-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.1.tgz",
+      "integrity": "sha512-vue7cRi1ZO5/72FJ+wZ5+siTSBlUv3ZksTk8bWD2IkaA6obitzMZP3yI65azTJLckwmi8lxfPP5Sd9oGuZ8e2g=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -498,6 +503,57 @@
           "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
           "requires": {
             "path-parse": "^1.0.6"
+          }
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "31.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-31.6.0.tgz",
+      "integrity": "sha512-kYhdW+BXHij9n12oHvAC27oDHKEFITz1YJP/C0NPtb+gsGJWxejh5B6dEmmj6oLYOsmNvuCVkdIcqYOyabP2QA==",
+      "requires": {
+        "comment-parser": "1.1.1",
+        "debug": "^4.3.1",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.20",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.4",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+          "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+          "requires": {
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         }
       }
@@ -964,6 +1020,11 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw=="
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1024,6 +1085,14 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "mimic-fn": {
@@ -1409,6 +1478,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
+    },
+    "regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w=="
     },
     "resolve": {
       "version": "1.11.0",
@@ -2039,6 +2113,11 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.20.2",
+    "eslint-plugin-jsdoc": "^31.6.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "prettier": "^2.0.2"


### PR DESCRIPTION
This PR introduces `eslint-plugin-jsdoc` as mentioned in https://github.com/openlayers/openlayers/issues/11960

At the moment I see 3 problems that will block the use of this plugin:
1. https://github.com/gajus/eslint-plugin-jsdoc/issues/686
2. https://github.com/gajus/eslint-plugin-jsdoc/issues/559
3. https://github.com/jsdoctypeparser/jsdoctypeparser/issues/133

This will allow a more rigid checking of the jsdocs. I tried it and it already detected some issues in the codebase, for example missing parameter descriptions or missing `@property` tags.

There are several stylistic rules that can be configured but will produce many problems in the codebase initially, but can be fixed easily. For example in the codebase `@return` is used way more often than `@returns` so we could check for that.

Also this plugin could help to move away from google closure syntax. Mainly `@property {Type=} prop` which could get replaced by `@property {Type} [prop]`. Another one is `@property {!Type} prop` which in my opinion could either get removed or get replaced by `"strictNullChecks": true` in the tsconfig. This produces 1075 issues though.