### PR TITLE
Updates to run linter on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,21 +10,31 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
+    name: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform }}
 
     strategy:
+      fail-fast: false
       matrix:
-        node-version:
-          - 14.x
+        platform:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        node:
+          - 16
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm ci
-    - run: npm test
-      env:
-        CI: true
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm test
+        env:
+          CI: true


### PR DESCRIPTION
By default, the `prettier/prettier` rule ensures that line endings are `\n` only (see the [`endOfLine` option](https://prettier.io/docs/en/options.html#end-of-line)).  Since the [OpenLayers repo](https://github.com/openlayers/openlayers) doesn't have a `.gitattributes` file checked in, people using Windows can only run the linter if they configure git (globally or locally) with the following:

```
git config core.autocrlf=false
git config core.eol=lf
```

This ensures that files in the repo use `\n` and files on disk use the same.

We could add a `gitattributes` file with `* text eol=lf` to make sure this is the setting for anybody who clones the repo.  Since we don't currently do that, we need to update `core.autocrlf` and `core.eol` before running the linter in CI.  This branch does that and runs the tests on Windows (in addition to Ubuntu and macOS).