### PR TITLE
Avoid duplicate imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = {
     curly: 'error',
     'default-case': 'error',
     'import/no-unresolved': ['error', {commonjs: true}],
+    'import/no-duplicates': 'error',
     'import/named': 'error',
     'import/default': 'error',
     'import/extensions': ['error', 'always', {ignorePackages: true}],

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "eslint-config-openlayers",
       "version": "16.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This adds the [`import/no-duplicates` rule](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md).