### PR TITLE
Prefer Object to object

### DIFF
--- a/examples/base/mod.js
+++ b/examples/base/mod.js
@@ -8,3 +8,66 @@ export function foo() {
   // option for prettier if not.
   return obj['bar'];
 }
+
+/**
+ * @typedef {Object} SoupOptions
+ * @property {string} [type='chicken'] The type of soup.
+ * @property {boolean} [noodles=false] Include noodles.
+ * @property {Array<string>} [vegetables=[]] The vegetables.
+ */
+
+/**
+ * @classdesc
+ * Soup.
+ *
+ * @api
+ */
+export class Soup {
+  /**
+   * Construct a soup.
+   * @param {SoupOptions} options The soup options.
+   */
+  constructor(options) {
+    /**
+     * @private
+     * @type {string}
+     */
+    this.type_ = options.type || 'chicken';
+
+    /**
+     * @private
+     * @type {boolean}
+     */
+    this.noodles_ = !!options.noodles;
+
+    /**
+     * @private
+     * @type {Array<string>}
+     */
+    this.vegetables_ = options.vegetables || [];
+  }
+
+  /**
+   * Get the soup type.
+   * @return {string} The type of soup.
+   */
+  getType() {
+    return this.type_;
+  }
+
+  /**
+   * Check if the soup has noodles.
+   * @return {boolean} The soup has noodles.
+   */
+  hasNoodles() {
+    return this.noodles_;
+  }
+
+  /**
+   * Get the vegetables.
+   * @return {Array<string>} The vegetables.
+   */
+  getVegetables() {
+    return this.vegetables_;
+  }
+}

--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ module.exports = {
       preferredTypes: {
         '[]': 'Array<>',
         '.<>': '<>',
+        'object': 'Object',
       },
       tagNamePreference: {
         'returns': 'return',


### PR DESCRIPTION
As of https://github.com/gajus/eslint-plugin-jsdoc/pull/248, the JSDoc plugin prefers `object` to `Object`.  For some reason, we haven't had to override this, and it hasn't been a problem to continue using `Object` with TypeScript.

To minimize the change in OpenLayers, this change adds a new setting so that JSDoc prefers `Object` to `object`.  With the latest release of the JSDoc plugin, this is now required (I'm not clear on which change made this the case).