### PR TITLE
Disable the no-undefined-types rule until template tag defaults work

### DIFF
--- a/examples/base/mod.js
+++ b/examples/base/mod.js
@@ -10,7 +10,22 @@ export function foo() {
 }
 
 /**
+ * @typedef {Object} FoodOptions
+ * @property {number} calories The number of calories.
+ */
+
+export class Food {
+  constructor(options) {
+    /**
+     * @type {number}
+     */
+    this.calories = options.calories;
+  }
+}
+
+/**
  * @typedef {Object} SoupOptions
+ * @property {number} calories The number of calories.
  * @property {string} [type='chicken'] The type of soup.
  * @property {boolean} [noodles=false] Include noodles.
  * @property {Array<string>} [vegetables=[]] The vegetables.
@@ -22,12 +37,14 @@ export function foo() {
  *
  * @api
  */
-export class Soup {
+export class Soup extends Food {
   /**
    * Construct a soup.
    * @param {SoupOptions} options The soup options.
    */
   constructor(options) {
+    super({calories: options.calories});
+
     /**
      * @private
      * @type {string}
@@ -69,5 +86,21 @@ export class Soup {
    */
   getVegetables() {
     return this.vegetables_;
+  }
+}
+
+/**
+ * @template {Food} [F=Soup]
+ */
+export class Restaurant {
+  /**
+   * @param {Array<F>} menu The menu items.
+   */
+  constructor(menu) {
+    /**
+     * @private
+     * @type {Array<F>}
+     */
+    this.menu_ = [];
   }
 }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     'jsdoc/empty-tags': 'error',
     'jsdoc/implements-on-classes': 'error',
     'jsdoc/no-bad-blocks': 'error',
-    'jsdoc/no-undefined-types': ['error', {'definedTypes': ['ol']}],
+    // 'jsdoc/no-undefined-types': ['error', {'definedTypes': ['ol']}], // blocked by https://github.com/gajus/eslint-plugin-jsdoc/issues/887
     'jsdoc/require-hyphen-before-param-description': ['error', 'never'],
     'jsdoc/require-param': 'error',
     'jsdoc/require-param-description': 'error',


### PR DESCRIPTION
A fix for the `no-undefined-types` rule with template tags went in with https://github.com/gajus/eslint-plugin-jsdoc/issues/559.  But the rule still doesn't work if the template tags have defaults.  See https://github.com/gajus/eslint-plugin-jsdoc/issues/887.

This change disables the `no-undefined-types` rule until the issue with template tag defaults is addressed.